### PR TITLE
Consider taxable compensation

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -4,7 +4,8 @@ new Vue({
   el: '#roth-calculator',
   data: {
     result: '???',
-    income: '52000',
+    magi: '52000',
+    taxable_compensation: '52000',
     age: '25',
     filing_status: 'single'
   },
@@ -17,27 +18,27 @@ new Vue({
       }
 
       if(this.filing_status === 'jointly' || this.filing_status === 'widow') {
-        if(this.income < 184000) {
-          this.result = Math.min(this.income, base_limit);
-        } else if(this.income >= 184000 && this.income < 194000) {
-          this.result = (1.0  - ((this.income - 184000) / 10000)) * base_limit
+        if(this.magi < 184000) {
+          this.result = Math.min(this.taxable_compensation, base_limit);
+        } else if(this.magi >= 184000 && this.magi < 194000) {
+          this.result = (1.0  - ((this.magi - 184000) / 10000)) * base_limit
         } else {
           this.result = 0
         }
       }
       else if(this.filing_status === 'mfs-lived-with') {
-        if(this.income < 10000) {
-          var max_result = (1.0  - (this.income / 10000)) * base_limit
-          this.result = Math.min(this.income, max_result)
+        if(this.magi < 10000) {
+          var max_result = (1.0  - (this.magi / 10000)) * base_limit
+          this.result = Math.min(this.taxable_compensation, max_result)
         } else {
           this.result = 0
         }
       }
       else if(this.filing_status === 'single' || this.filing_status === 'mfs-lived-without') {
-        if(this.income < 117000) {
-          this.result = Math.min(this.income, base_limit);
-        } else if(this.income >= 117000 && this.income < 132000) {
-          this.result = (1.0  - ((this.income - 117000) / 15000)) * base_limit
+        if(this.magi < 117000) {
+          this.result = Math.min(this.taxable_compensation, base_limit);
+        } else if(this.magi >= 117000 && this.magi < 132000) {
+          this.result = (1.0  - ((this.magi - 117000) / 15000)) * base_limit
         } else {
           this.result = 0
         }

--- a/views/index.jade
+++ b/views/index.jade
@@ -31,7 +31,12 @@ block content
     h4 2016 Modified Adjusted Gross Income
       sup [1][3]*
 
-    input(v-model="income" type="number")
+    input(v-model="magi" type="number")
+
+    h4 2016 Taxable Compensation
+      sup [2][5]+
+
+    input(v-model="taxable_compensation" type="number")
 
     h4 Age
       sup [2][4]
@@ -55,8 +60,11 @@ block content
     a(href="https://www.irs.gov/businesses/small-businesses-self-employed/passive-activity-loss-atg-exhibit-2-2-modified-adjusted-gross-income-computation") Passive Activity Loss ATG - Exhibit 2.2: Modified Adjusted Gross Income Computation
   p [4] IRS (7-Dec-2015).
     a(href="https://www.irs.gov/retirement-plans/roth-iras") Roth IRAs
+  p [5] IRS (2015).
+    a(href="https://www.irs.gov/pub/irs-pdf/f1040.pdf") Form 1040
 
   h2 Editors Notes
   p * This is effectively the amount of money that you've made, but you can't subtract losses/expenses that are usually considered write-offs.
+  p + Very frequently, this is the same value as your Modified Adjusted Gross Income.  You can figure out this value by completing your 1040 form.  This value is the value on line 43.
 
   a(href="https://github.com/BrandonRomano/roth-ira-contribution-calculator") Check out the source code here


### PR DESCRIPTION
I was previously putting MAGI + Taxable income into the same bucket.

Reddit user [Mrme487](https://www.reddit.com/user/Mrme487) pointed out in [a personal finance thread](https://www.reddit.com/r/personalfinance/comments/4xmj44/a_simple_calculator_to_see_how_much_you_can/) that this is not always the case.

https://www.irs.gov/retirement-plans/plan-participant-employee/retirement-topics-ira-contribution-limits

> For 2015 and 2016, your total contributions to all of your traditional and Roth IRAs cannot be more than:
> ... 
> your taxable compensation for the year, if your compensation was less than this dollar limit.
